### PR TITLE
fix test util, fix promise handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3519,6 +3519,21 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.0.tgz",
+      "integrity": "sha512-Ke15MBbbhyIhZzWheiWuRlTO81tTH4RQvrbJFpVzJce8oyVrCVSDdrcw4TcyMsaS/fMGJSbU3lTsqCGDKwrzww==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3536,6 +3551,23 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "joi": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.1.tgz",
+      "integrity": "sha512-Y44bDwIoeCjFDRO18VaMRc0hIdPkLbZaF2VqU7t1tCcno3S3XzsmlYYpOu0Qk6nkzoI5RSao7W57NTvPKxbkcg==",
+      "requires": {
+        "hoek": "5.0.2",
+        "isemail": "3.1.0",
+        "topo": "3.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+          "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
+        }
+      }
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -5937,9 +5969,9 @@
       }
     },
     "ormnomnom": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ormnomnom/-/ormnomnom-5.0.0.tgz",
-      "integrity": "sha512-nRmWxQZID+/TbUsyTszzy4ElYtG3000/UtxJQJt5NH1E4WvV80ASbP2ix7ktKOCSDN5bX21th+9jmjx5bhgNcw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ormnomnom/-/ormnomnom-5.0.1.tgz",
+      "integrity": "sha512-tjwSTsjSn28pkCy3dWvaqOZlxD0xOCMd0Uk//H2GZ7O5s8v+itTa61AouPpNCDRvBYoNyq43+L9sLWBveg7TEQ==",
       "requires": {
         "@iterables/chain": "1.0.1",
         "@iterables/map": "1.0.1",
@@ -5950,44 +5982,6 @@
         "joi": "13.1.1",
         "pg-query-stream": "1.1.1",
         "quotemeta": "0.0.0"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
-          "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
-        },
-        "isemail": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.0.tgz",
-          "integrity": "sha512-Ke15MBbbhyIhZzWheiWuRlTO81tTH4RQvrbJFpVzJce8oyVrCVSDdrcw4TcyMsaS/fMGJSbU3lTsqCGDKwrzww==",
-          "requires": {
-            "punycode": "2.1.0"
-          }
-        },
-        "joi": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.1.tgz",
-          "integrity": "sha512-Y44bDwIoeCjFDRO18VaMRc0hIdPkLbZaF2VqU7t1tCcno3S3XzsmlYYpOu0Qk6nkzoI5RSao7W57NTvPKxbkcg==",
-          "requires": {
-            "hoek": "5.0.2",
-            "isemail": "3.1.0",
-            "topo": "3.0.0"
-          }
-        },
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        },
-        "topo": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
-          "requires": {
-            "hoek": "5.0.2"
-          }
-        }
       }
     },
     "os-homedir": {
@@ -7444,6 +7438,21 @@
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
       "integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ==",
       "dev": true
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.2"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+          "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
+        }
+      }
     },
     "tough-cookie": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "numbat-emitter": "^5.0.0",
     "numbat-process": "^2.2.1",
     "once": "^1.4.0",
-    "ormnomnom": "^5.0.0",
+    "ormnomnom": "^5.0.1",
     "parse-link-header": "^1.0.1",
     "percentile": "^1.2.0",
     "pg": "^6.1.5",

--- a/spife.js
+++ b/spife.js
@@ -240,7 +240,14 @@ function destroyStreamOnClose (stream) {
 }
 
 function middlewareMembrane1 (req, next) {
-  return next(req).then(result => {
+  let getResult
+  try {
+    getResult = Promise.resolve(next(req))
+  } catch (err) {
+    getResult = Promise.reject(err)
+  }
+
+  return getResult.then(result => {
     return checkMiddlewareResolution(result)
   }).catch(err => {
     throw checkMiddlewareRejection(err)
@@ -248,7 +255,14 @@ function middlewareMembrane1 (req, next) {
 }
 
 function middlewareMembrane3 (req, match, context, next) {
-  return next(req, match, context).then(result => {
+  let getResult
+  try {
+    getResult = Promise.resolve(next(req, match, context))
+  } catch (err) {
+    getResult = Promise.reject(err)
+  }
+
+  return getResult.then(result => {
     return checkMiddlewareResolution(result)
   }).catch(err => {
     throw checkMiddlewareRejection(err)

--- a/spife.js
+++ b/spife.js
@@ -239,20 +239,20 @@ function destroyStreamOnClose (stream) {
   else stream.resume()
 }
 
-async function middlewareMembrane1 (req, next) {
-  try {
-    return checkMiddlewareResolution(await next(req))
-  } catch (err) {
+function middlewareMembrane1 (req, next) {
+  return next(req).then(result => {
+    return checkMiddlewareResolution(result)
+  }).catch(err => {
     throw checkMiddlewareRejection(err)
-  }
+  })
 }
 
-async function middlewareMembrane3 (req, match, context, next) {
-  try {
-    return checkMiddlewareResolution(await next(req, match, context))
-  } catch (err) {
+function middlewareMembrane3 (req, match, context, next) {
+  return next(req, match, context).then(result => {
+    return checkMiddlewareResolution(result)
+  }).catch(err => {
     throw checkMiddlewareRejection(err)
-  }
+  })
 }
 
 function checkMiddlewareResolution (response) {

--- a/utils/test.js
+++ b/utils/test.js
@@ -82,7 +82,7 @@ function createTransactionalTest (baseTest, routes, middleware, dbName, port) {
       var rollbackTransaction = null
       /* eslint-disable promise/param-names */
       const transactionPromise = new Promise((_, reject) => {
-        rollbackTransaction = reject
+        rollbackTransaction = () => reject(new Error('Rolling back transaction'))
       })
       /* eslint-enable promise/param-names */
 

--- a/utils/test.js
+++ b/utils/test.js
@@ -111,17 +111,17 @@ function createTransactionalTest (baseTest, routes, middleware, dbName, port) {
             session.assign(process.domain)
             db.session.queries = []
             db.session.startTime = Date.now()
-            return next()
+            return next(req)
           })
         }
       }
       const trackRouteQueryCountMW = {
         processView (req, match, context, next) {
           db.session.routeName = req.viewName
-          return next()
+          return next(req, match, context)
         },
         processRequest (req, next) {
-          return next().then(resp => {
+          return next(req).then(resp => {
             aggregateInfo(
               db.session.routeName,
               db.session.queries,


### PR DESCRIPTION
the test util needed updated to follow the correct middleware pattern

the `middlewareMembraneN` functions were modified to return a promise rather than use async/await to ensure that domains propagate correctly due to internal V8 magic