### PR TITLE
Tutorial: Fix error when creating tables

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,14 +85,14 @@ have it, run `createdb spife_example`, and then run the following inside of
 
 ```sql
 > CREATE TABLE "destinations" (
-  id serial,
+  id serial primary key,
   name text not null,
   slug text unique not null,
   address text not null,
   created date
 );
 > CREATE TABLE "packages" (
-  id serial,
+  id serial primary key,
   public_id varchar(36) unique not null,
   destination_id integer not null references destinations(id),
   contents text not null,


### PR DESCRIPTION
When I try to create the packages table, I encounter an error message:

```
ERROR:  there is no unique constraint matching given keys for referenced table "destinations"
```
I believe it is necessary for there to be a unique index on columns referenced by foreign keys.
It's probably best that these tables each have an explicitly declared primary key.

(I am using PostgreSQL 10.3.)