### PR TITLE
fix(test-database mw): when intercepting a stream response, collect the stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/spife",
-  "version": "11.1.6",
+  "version": "11.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4263,6 +4263,7 @@
       "version": "11.7.2",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.7.2.tgz",
       "integrity": "sha512-gBt7qwsR1vryYfglVjQRx1D+AtMZW5NbUKxb+lZe8SN8KsheGCPGWEsSC9AGQG+r2+te1+10uPHUCahuqm1nGQ==",
+      "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "arrify": "^1.0.1",
@@ -4296,6 +4297,7 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4304,62 +4306,76 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chalk": "^1.1.3",
             "esutils": "^2.0.2",
@@ -4369,6 +4385,7 @@
         "babel-generator": {
           "version": "6.26.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-messages": "^6.23.0",
             "babel-runtime": "^6.26.0",
@@ -4383,6 +4400,7 @@
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.22.0"
           }
@@ -4390,6 +4408,7 @@
         "babel-runtime": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "core-js": "^2.4.0",
             "regenerator-runtime": "^0.11.0"
@@ -4398,6 +4417,7 @@
         "babel-template": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
             "babel-traverse": "^6.26.0",
@@ -4409,6 +4429,7 @@
         "babel-traverse": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
             "babel-messages": "^6.23.0",
@@ -4424,6 +4445,7 @@
         "babel-types": {
           "version": "6.26.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
             "esutils": "^2.0.2",
@@ -4433,15 +4455,18 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "base": {
           "version": "0.11.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
             "class-utils": "^0.3.5",
@@ -4455,6 +4480,7 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -4462,6 +4488,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4469,6 +4496,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4476,6 +4504,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -4484,13 +4513,15 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4499,6 +4530,7 @@
         "braces": {
           "version": "2.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -4515,6 +4547,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4523,11 +4556,13 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
             "component-emitter": "^1.2.1",
@@ -4543,6 +4578,7 @@
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
             "mkdirp": "^0.5.1",
@@ -4552,11 +4588,13 @@
         "camelcase": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "^0.1.3",
@@ -4566,6 +4604,7 @@
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -4577,6 +4616,7 @@
         "class-utils": {
           "version": "0.3.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "define-property": "^0.2.5",
@@ -4587,6 +4627,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -4596,6 +4637,7 @@
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "^0.1.1",
@@ -4606,17 +4648,20 @@
             "wordwrap": {
               "version": "0.0.2",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
             "object-visit": "^1.0.0"
@@ -4624,31 +4669,38 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-js": {
           "version": "2.5.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
@@ -4657,25 +4709,30 @@
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
           }
@@ -4683,6 +4740,7 @@
         "define-property": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -4691,6 +4749,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4698,6 +4757,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4705,6 +4765,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -4713,13 +4774,15 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "repeating": "^2.0.0"
           }
@@ -4727,21 +4790,25 @@
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "execa": {
           "version": "0.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -4755,6 +4822,7 @@
             "cross-spawn": {
               "version": "5.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -4766,6 +4834,7 @@
         "expand-brackets": {
           "version": "2.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -4779,6 +4848,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -4786,6 +4856,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4795,6 +4866,7 @@
         "extend-shallow": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -4803,6 +4875,7 @@
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -4812,6 +4885,7 @@
         "extglob": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -4826,6 +4900,7 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -4833,6 +4908,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4840,6 +4916,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4847,6 +4924,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -4854,6 +4932,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -4862,13 +4941,15 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -4879,6 +4960,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4888,6 +4970,7 @@
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "commondir": "^1.0.1",
             "mkdirp": "^0.5.1",
@@ -4897,17 +4980,20 @@
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "^4",
             "signal-exit": "^3.0.0"
@@ -4916,29 +5002,35 @@
         "fragment-cache": {
           "version": "0.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4950,15 +5042,18 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "async": "^1.4.0",
             "optimist": "^0.6.1",
@@ -4969,6 +5064,7 @@
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -4978,17 +5074,20 @@
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "get-value": "^2.0.6",
             "has-values": "^1.0.0",
@@ -4998,6 +5097,7 @@
         "has-values": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "kind-of": "^4.0.0"
@@ -5006,6 +5106,7 @@
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -5014,15 +5115,18 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -5030,37 +5134,44 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "invariant": {
           "version": "2.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
           }
@@ -5068,6 +5179,7 @@
         "is-data-descriptor": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -5075,6 +5187,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -5083,28 +5196,33 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-number": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -5112,54 +5230,65 @@
         "is-odd": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "^3.0.1"
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
           }
@@ -5167,6 +5296,7 @@
         "istanbul-lib-instrument": {
           "version": "1.10.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "babel-generator": "^6.18.0",
             "babel-template": "^6.16.0",
@@ -5180,6 +5310,7 @@
         "istanbul-lib-report": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
             "mkdirp": "^0.5.1",
@@ -5190,6 +5321,7 @@
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
               }
@@ -5199,6 +5331,7 @@
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debug": "^3.1.0",
             "istanbul-lib-coverage": "^1.1.2",
@@ -5210,6 +5343,7 @@
             "debug": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -5219,21 +5353,25 @@
         "istanbul-reports": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5241,11 +5379,13 @@
         "lazy-cache": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
           }
@@ -5253,6 +5393,7 @@
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
@@ -5264,6 +5405,7 @@
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -5271,21 +5413,25 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.10",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "js-tokens": "^3.0.0"
           }
@@ -5293,6 +5439,7 @@
         "lru-cache": {
           "version": "4.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -5300,11 +5447,13 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
           }
@@ -5312,17 +5461,20 @@
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mem": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
           }
@@ -5330,19 +5482,22 @@
         "merge-source-map": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "source-map": "^0.6.1"
           },
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -5361,28 +5516,33 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -5391,6 +5551,7 @@
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -5400,17 +5561,20 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -5428,13 +5592,15 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "is-builtin-module": "^1.0.0",
@@ -5445,21 +5611,25 @@
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
             "define-property": "^0.2.5",
@@ -5469,6 +5639,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -5478,6 +5649,7 @@
         "object-visit": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "^3.0.0"
           }
@@ -5485,6 +5657,7 @@
         "object.pick": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isobject": "^3.0.1"
           }
@@ -5492,6 +5665,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5499,6 +5673,7 @@
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "~0.0.1",
             "wordwrap": "~0.0.2"
@@ -5506,11 +5681,13 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
@@ -5519,11 +5696,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -5531,47 +5710,56 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -5580,15 +5768,18 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
           }
@@ -5596,6 +5787,7 @@
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "find-up": "^1.0.0"
           },
@@ -5603,6 +5795,7 @@
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -5612,15 +5805,18 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
             "normalize-package-data": "^2.3.2",
@@ -5630,6 +5826,7 @@
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "find-up": "^1.0.0",
             "read-pkg": "^1.0.0"
@@ -5638,6 +5835,7 @@
             "find-up": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -5647,11 +5845,13 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
@@ -5659,42 +5859,51 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "^0.1.1"
@@ -5703,6 +5912,7 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -5710,21 +5920,25 @@
         "safe-regex": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ret": "~0.1.10"
           }
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-value": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -5735,6 +5949,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -5744,25 +5959,30 @@
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "base": "^0.11.1",
             "debug": "^2.2.0",
@@ -5777,6 +5997,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -5784,6 +6005,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -5793,6 +6015,7 @@
         "snapdragon-node": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "^1.0.0",
             "isobject": "^3.0.0",
@@ -5802,6 +6025,7 @@
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -5809,6 +6033,7 @@
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -5816,6 +6041,7 @@
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
               }
@@ -5823,6 +6049,7 @@
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -5831,24 +6058,28 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
           }
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "atob": "^2.0.0",
             "decode-uri-component": "^0.2.0",
@@ -5859,11 +6090,13 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
             "mkdirp": "^0.5.0",
@@ -5876,6 +6109,7 @@
         "spdx-correct": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -5883,11 +6117,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -5895,11 +6131,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "split-string": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
           }
@@ -5907,6 +6145,7 @@
         "static-extend": {
           "version": "0.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "^0.2.5",
             "object-copy": "^0.1.0"
@@ -5915,6 +6154,7 @@
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -5924,6 +6164,7 @@
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -5931,11 +6172,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -5945,6 +6188,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5952,21 +6196,25 @@
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arrify": "^1.0.1",
             "micromatch": "^3.1.8",
@@ -5977,11 +6225,13 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -5989,6 +6239,7 @@
         "to-regex": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-property": "^2.0.2",
             "extend-shallow": "^3.0.2",
@@ -5999,6 +6250,7 @@
         "to-regex-range": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
@@ -6006,11 +6258,13 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "source-map": "~0.5.1",
@@ -6021,6 +6275,7 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
+              "dev": true,
               "optional": true,
               "requires": {
                 "camelcase": "^1.0.2",
@@ -6034,11 +6289,13 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
@@ -6049,6 +6306,7 @@
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -6056,6 +6314,7 @@
             "set-value": {
               "version": "0.4.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -6068,6 +6327,7 @@
         "unset-value": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-value": "^0.3.1",
             "isobject": "^3.0.0"
@@ -6076,6 +6336,7 @@
             "has-value": {
               "version": "0.3.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
                 "has-values": "^0.1.4",
@@ -6085,6 +6346,7 @@
                 "isobject": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
                   }
@@ -6093,30 +6355,35 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "use": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -6125,26 +6392,31 @@
         "which": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
@@ -6153,6 +6425,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6160,6 +6433,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6170,11 +6444,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -6183,15 +6459,18 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yargs": {
           "version": "11.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
@@ -6209,15 +6488,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "cliui": {
               "version": "4.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
@@ -6227,6 +6509,7 @@
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -6234,6 +6517,7 @@
             "yargs-parser": {
               "version": "9.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
               }
@@ -6243,13 +6527,15 @@
         "yargs-parser": {
           "version": "8.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bluebird": "^3.5.1",
     "bole": "^3.0.2",
     "chokidar": "^2.0.3",
+    "concat-stream": "^1.6.2",
     "cookie": "^0.3.1",
     "dotenv": "^4.0.0",
     "find-up": "^2.1.0",


### PR DESCRIPTION
Some streams may make DB queries during a `_transform` step. Make sure that these happen within our atomic function by casting the stream to a reply stream, collecting the results, and re-applying the correct headers+status before they exit the processRequest lifecycle of this middleware.