### PR TITLE
Fix: Incorrect/non-public URL in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ in the repository directory. From there you can:
 
 ISC
 
-[bole]: http://github.com/rvagg/bole
+[bole]: https://github.com/rvagg/bole
 [docs]: ./docs
 [getting-started]: ./docs/getting-started.md
 [faq]: ./docs/faq.md
@@ -95,7 +95,7 @@ ISC
 [ref-transaction]: ./docs/reference/decorator-transaction.md
 [ref-validate]: ./docs/reference/decorator-validate.md
 [ref-view-paginate]: ./docs/reference/view-paginate.md
-[restify-monitor]: https://github.com/npm/restify-monitor
+[restify-monitor]: https://www.npmjs.com/package/@ceejbot/restify-monitor
 [reverse]: https://github.com/chrisdickinson/reverse
 [topic-ethos]: ./docs/topics/ethos.md
 [topic-request-lifecycle]: ./docs/topics/request-lifecycle.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -786,7 +786,7 @@ specifically configured for your Spife server — easy as that!
 
 [numbat-emitter]: https://github.com/ceejbot/numbat-emitter
 
-[restify-monitor]: https://github.com/npm/restify-monitor
+[restify-monitor]: https://www.npmjs.com/package/@ceejbot/restify-monitor
 
 [bole]: http://github.com/rvagg/bole
 


### PR DESCRIPTION
Oh hello! 👋

I'm opening the tinyest PR to change the `restify-monitor` link in the docs from https://github.com/npm/restify-monitor, which 404s (I assume this probably exists, but is not public), to this: https://www.npmjs.com/package/@ceejbot/restify-monitor which is public.

Let me know if I can adjust anything, thanks!
